### PR TITLE
Use opaque color for peek view sticky scroll background for readability

### DIFF
--- a/themes/Snazzy-Light-color-theme.json
+++ b/themes/Snazzy-Light-color-theme.json
@@ -132,7 +132,7 @@
     "peekViewEditor.background": "#14B1FF08",
     "peekViewEditor.matchHighlightBackground": "#F5B90088",
     "peekViewEditor.matchHighlightBorder": "#F5B900",
-    "peekViewEditorStickyScroll.background": "#F3F4F5",
+    "peekViewEditorStickyScroll.background": "#EDF4FB",
     "peekViewResult.selectionBackground": "#09A1ED",
     "peekViewResult.selectionForeground": "#FFFFFF",
     "peekViewResult.matchHighlightBackground": "#F5B90088",

--- a/themes/Snazzy-Light-color-theme.json
+++ b/themes/Snazzy-Light-color-theme.json
@@ -132,6 +132,7 @@
     "peekViewEditor.background": "#14B1FF08",
     "peekViewEditor.matchHighlightBackground": "#F5B90088",
     "peekViewEditor.matchHighlightBorder": "#F5B900",
+    "peekViewEditorStickyScroll.background": "#F3F4F5",
     "peekViewResult.selectionBackground": "#09A1ED",
     "peekViewResult.selectionForeground": "#FFFFFF",
     "peekViewResult.matchHighlightBackground": "#F5B90088",


### PR DESCRIPTION
I love this theme! But one issue I constantly run into is that the peek view sticky header is translucent, making it unreadable:

<img width="384" alt="image" src="https://github.com/loilo/vscode-snazzy-light/assets/1612169/36a0d890-67d1-43bd-9199-8812cab66ac8">

I figured out the color key to override this (`peekViewEditorStickyScroll.background`), but I'm not exactly sure what color to use, so this is just a draft, feel free to build on top of it to pick a better color!

After:

<img width="303" alt="image" src="https://github.com/loilo/vscode-snazzy-light/assets/1612169/edbce755-1480-4e36-bf7c-7c554e3d967b">
